### PR TITLE
Use rake task to allow setting checkout URL

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -43,23 +43,32 @@ ${CLI} config:set SECRET_TOKEN="$secret_token"
 # migrate
 ${CLI} run rake ${rake_commands} || true
 
+# set various settings
+sys_api_key=$(${CLI} config:get SYS_API_KEY)
+web_protocol="$(${CLI} config:get SERVER_PROTOCOL)"
+web_hostname="$(${CLI} config:get SERVER_HOSTNAME)"
+web_url="${web_protocol}://${web_hostname}"
+${CLI} run rake setting:set[host_name=${web_hostname},protocol=${web_protocol},sys_api_enabled=1,sys_api_key=${sys_api_key}] 1>/dev/null
+
 # Avoid errors on versions < 5.0
 if [ -e "${APP_HOME}/lib/tasks/scm.rake" ]; then
-	# migrate previous repositories with reposman to managed
 	SVN_REPOSITORIES=$(${CLI} config:get SVN_REPOSITORIES || echo "")
+	GIT_REPOSITORIES=$(${CLI} config:get GIT_REPOSITORIES || echo "")
+
 	if [ -n "$SVN_REPOSITORIES" ]; then
+		# migrate previous repositories with reposman to managed
 		${CLI} run rake scm:migrate:managed["file://${SVN_REPOSITORIES}"] || true
+
+		${CLI} run rake scm:set_checkout_url["subversion='${web_url}/svn'"] || true
+	fi
+
+	if [ -n "$GIT_REPOSITORIES" ]; then
+		${CLI} run rake scm:set_checkout_url["git='${web_url}/svn'"] || true
 	fi
 
 	# Output any remnants of existing repositories
 	${CLI} run rake scm:find_unassociated || true
 fi
-
-# set various settings
-sys_api_key=$(${CLI} config:get SYS_API_KEY)
-web_protocol="$(${CLI} config:get SERVER_PROTOCOL)"
-web_hostname="$(${CLI} config:get SERVER_HOSTNAME)"
-${CLI} run rake setting:set[host_name=${web_hostname},protocol=${web_protocol},sys_api_enabled=1,sys_api_key=${sys_api_key}] 1>/dev/null
 
 # scale
 ${CLI} scale web=1 worker=1 || true


### PR DESCRIPTION
This commit uses the rake task `scm:set_checkout_url` from OpenProject to configure
repository checkout URLs from outside, e.g., from packager without
knowledge of the checkout data structure.

With this task, we can instrument the packager postinstall to set the
checkout data automatically from the values it has been configured with.

Functionality depends on https://github.com/opf/openproject/pull/3908. For earlier releases in 5.0 , this causes the output (but does not cancel the build):

`Don't know how to build task 'scm:set_checkout_url'`

I think this output is temporarily justifiable.
