### PR TITLE
Bump WEB_TIMEOUT

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -45,7 +45,7 @@ web_concurrency=$(${CLI} config:get WEB_CONCURRENCY || echo "2")
 ${CLI} config:set WEB_CONCURRENCY=${web_concurrency}
 
 # set web timeout
-web_timeout=$(${CLI} config:get WEB_TIMEOUT || echo "15")
+web_timeout=$(${CLI} config:get WEB_TIMEOUT || echo "300")
 ${CLI} config:set WEB_TIMEOUT=${web_timeout}
 
 # set SECRET_KEY_BASE env variable


### PR DESCRIPTION
From the previous packager experience, we do not have actions that may cause worker to freeze and thus be correctly reaped. On the other hand, I have increased this limit on all deployments so far and based on [this request](https://community.openproject.com/topics/6852?r=6854#message-6854), I suggest to finally bump this limit here.

/cc @crohr 